### PR TITLE
Bug.segmentation unallocated out of bounds

### DIFF
--- a/TeachingTools/quiz_generation/premade_questions/memory_questions.py
+++ b/TeachingTools/quiz_generation/premade_questions/memory_questions.py
@@ -455,7 +455,7 @@ class Segmentation(MemoryAccessQuestion):
       "stack" : 0,
     }
     
-    min_bounds = 8
+    min_bounds = 4
     max_bounds = int(2**(self.virtual_bits - 2))
     
     def segment_collision(base, bounds):
@@ -471,7 +471,7 @@ class Segmentation(MemoryAccessQuestion):
     # Make random placements and check to make sure they are not overlapping
     while (segment_collision(self.base, self.bounds)):
       for segment in self.base.keys():
-        self.bounds[segment] = random.randint(min_bounds, max_bounds)
+        self.bounds[segment] = random.randint(min_bounds, max_bounds-1)
         self.base[segment] = random.randint(0, (2**self.physical_bits - self.bounds[segment]))
     
     # Pick a random segment for us to use
@@ -487,13 +487,13 @@ class Segmentation(MemoryAccessQuestion):
     try:
       self.offset = random.randint(0,
         min([
-          ((self.virtual_bits-2)**2)-1,
+          max_bounds-1,
           int(self.bounds[self.segment] / self.PROBABILITY_OF_VALID)
         ])
       )
     except KeyError:
       # If we are in an unallocated section, we'll get a key error (I think)
-      self.offset = random.randint(0, ((self.virtual_bits-2)**2)-1)
+      self.offset = random.randint(0, max_bounds-1)
     
     # Calculate a virtual address based on the segment and the offset
     self.virtual_address = (
@@ -822,8 +822,3 @@ class Paging(MemoryAccessQuestion):
       ""
     ])
     return lines
-
-#########################
-# todo: below this line #
-#########################
-

--- a/generate_quiz.py
+++ b/generate_quiz.py
@@ -20,6 +20,10 @@ def parse_args():
   parser.add_argument("--num_canvas", default=0, type=int)
   parser.add_argument("--num_pdfs", default=0, type=int)
   
+  subparsers = parser.add_subparsers(dest='command')
+  test_parser = subparsers.add_parser("TEST")
+  
+  
   args = parser.parse_args()
   
   if args.num_canvas > 0 and args.course_id is None:
@@ -27,10 +31,17 @@ def parse_args():
     exit(8)
   
   return args
+def test():
+  log.info("Running test...")
+  pass
 
 def main():
   
   args = parse_args()
+  
+  if args.command == "TEST":
+    test()
+    return
   
   quizzes = Quiz.from_yaml(args.quiz_yaml)
   for quiz in quizzes:


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of what this PR accomplishes -->
Fixing an issue in segmentation questions where unallocated virtual address could overflow into the stack leading to inaccurate questions

## Changes Made
<!-- List the key changes made in this PR -->
- Offsets now are chosen to always be between `max_bounds - 1` at very most.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Done
<!-- Describe the testing you've done to verify your changes -->
Ran 1000x to see if I got any bad addresses and saw none

## Checklist
<!-- Mark the appropriate options with an [x] -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots here if they help explain your changes -->

## Notes
<!-- Any additional notes or context about the PR -->
