### PR TITLE
Adding in a snippet in the assignment where there are allowed filenames and when grading submissions filenames are checked for similarity and assigned based on fuzzywuzzy similarity. This renaming is correcting for when students don't submit files with the base names of `student_code.c` (or equivalent)

### DIFF
--- a/TeachingTools/lms_interface/canvas_interface.py
+++ b/TeachingTools/lms_interface/canvas_interface.py
@@ -24,7 +24,7 @@ import logging
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+log.setLevel(logging.INFO)
 
 
 logger = logging.getLogger("canvasapi")
@@ -267,7 +267,6 @@ class CanvasAssignment(LMSWrapper):
         else:
           log.warning(f"Failed to delete comment {comment_id}: {response.json()}")
     
-    
     def upload_buffer_as_file(buffer, name):
       with io.FileIO(name, 'w+') as ffid:
         ffid.write(buffer)
@@ -307,7 +306,7 @@ class CanvasAssignment(LMSWrapper):
         _inner=self.canvas_course.get_user(canvaspai_submission.user_id)
       )
       
-      log.info(f"Checking submissions for {student.name} ({len(canvaspai_submission.submission_history)} submissions)")
+      log.debug(f"Checking submissions for {student.name} ({len(canvaspai_submission.submission_history)} submissions)")
       
       # Walk through submissions in the reverse order, so we'll default to grabbing the most recent submission first
       # This is important when we are going to be only including most recent

--- a/TeachingTools/lms_interface/classes.py
+++ b/TeachingTools/lms_interface/classes.py
@@ -116,7 +116,6 @@ class Submission__Canvas(Submission):
       for attachment in self._attachments:
         
         # Generate a local file name with a number of options
-        # todo: make this into a fake file perhaps?
         # local_file_name = f"{self.student.name.replace(' ', '-')}_{self.student.user_id}_{attachment['filename']}"
         local_file_name = f"{attachment['filename']}"
         with urllib.request.urlopen(attachment['url']) as response:


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of what this PR accomplishes -->
Fixing a bug where students submitting incorrectly named files (e.g. "sam student_code.c" instead of "student_code.c") would not be graded appropriately.

## Changes Made
<!-- List the key changes made in this PR -->
- Files are now automatically renamed to an approved list by using a string similarity heuristic.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing Done
<!-- Describe the testing you've done to verify your changes -->

## Checklist
<!-- Mark the appropriate options with an [x] -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
